### PR TITLE
Handle data-correct attribute on radio labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,7 +569,10 @@ function submitQuiz(btn, quizType) {
     radios.forEach(radio => {
       if (radio.checked) {
         answered = true;
-        if (radio.getAttribute('data-correct') === 'true') userCorrect = true;
+        const isCorrect =
+          radio.getAttribute('data-correct') === 'true' ||
+          radio.parentElement?.getAttribute('data-correct') === 'true';
+        if (isCorrect) userCorrect = true;
       }
       // Reset label
       radio.parentElement.removeAttribute('data-result');


### PR DESCRIPTION
## Summary
- Fix quiz submission logic to recognize `data-correct` on label or input elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892a48ccdfc8326a9aefa68446ced3d