### PR TITLE
Add CORS handling and error reporting for Apps Script submissions

### DIFF
--- a/timber-technology-assessment.html
+++ b/timber-technology-assessment.html
@@ -478,14 +478,23 @@
       };
 
       try {
-        await fetch(SCRIPT_URL, {
+        const response = await fetch(SCRIPT_URL, {
           method: "POST",
-          mode: "no-cors",
           headers: {
             "Content-Type": "application/json"
           },
           body: JSON.stringify(payload)
         });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(errorText || `HTTP ${response.status}`);
+        }
+
+        const result = await response.json();
+        if (!result || result.status !== "success") {
+          throw new Error((result && result.message) || "Unknown server response");
+        }
 
         statusMessage.textContent = "✅ Submission received. You may now close this tab.";
         statusMessage.classList.add("status-success");


### PR DESCRIPTION
## Summary
- add CORS-friendly responses and OPTIONS handler to the Apps Script endpoint
- return structured JSON success and error payloads for easier client handling
- update the assessment form submission to surface HTTP errors instead of using an opaque request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eed4fedbec8326b500ca50d76b50e3