### PR TITLE
Improve assessment submission reliability

### DIFF
--- a/timber-technology-assessment.html
+++ b/timber-technology-assessment.html
@@ -480,8 +480,9 @@
       try {
         const response = await fetch(SCRIPT_URL, {
           method: "POST",
+          mode: "cors",
           headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "text/plain;charset=utf-8"
           },
           body: JSON.stringify(payload)
         });
@@ -511,7 +512,12 @@
         statusMessage.classList.add("status-success");
       } catch (error) {
         console.error(error);
-        const details = error && error.message ? ` ${error.message}` : "";
+        let details = "";
+        if (error instanceof TypeError || (error && error.name === "TypeError")) {
+          details = " Unable to reach the marking spreadsheet service. Please check your connection and try again.";
+        } else if (error && typeof error.message === "string" && error.message.trim().length) {
+          details = ` ${error.message.trim()}`;
+        }
         statusMessage.textContent = `⚠️ There was a problem submitting your responses.${details} Please notify your teacher immediately.`;
         statusMessage.classList.add("status-error");
       } finally {


### PR DESCRIPTION
## Summary
- send the assessment payload using a simple CORS-friendly content type
- provide clearer messaging when the spreadsheet service cannot be reached

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eee042d9dc83269dc61e7835b1ec51