### PR TITLE
Add Year 10 Weeks 1-20 theory exam page

### DIFF
--- a/sections/assessment.html
+++ b/sections/assessment.html
@@ -4,5 +4,6 @@
       <ul>
         <li><a href="AssessmentInfo.pdf" target="_blank">Download Assessment Information (PDF)</a></li>
         <li><a href="https://drive.google.com/file/d/1JNHqjMPDDN37x3I5X-YAj0Y_mxTSseDg/view?usp=drive_link" target="_blank">View Assessment Schedule</a></li>
+        <li><a href="yr10-weeks1-20-exam.html" target="_blank">Year 10 Weeks 1&ndash;20 Theory Examination (60 minutes)</a></li>
       </ul>
     </div>

--- a/yr10-weeks1-20-exam.html
+++ b/yr10-weeks1-20-exam.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Year 10 Industrial Technology Timber &mdash; Weeks 1&ndash;20 Theory Examination</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      font-family: "Segoe UI", Arial, sans-serif;
+      margin: 0 auto;
+      padding: 40px 20px 60px;
+      max-width: 960px;
+      line-height: 1.6;
+      color: #222;
+      background-color: #f7f7f7;
+    }
+    header {
+      text-align: center;
+      margin-bottom: 30px;
+      padding-bottom: 20px;
+      border-bottom: 4px solid #0d6efd;
+    }
+    h1 {
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      margin-bottom: 10px;
+      color: #0d3f8c;
+    }
+    h2 {
+      color: #0d3f8c;
+      margin-top: 36px;
+      border-bottom: 2px solid rgba(13, 63, 140, 0.2);
+      padding-bottom: 6px;
+    }
+    h3 {
+      margin-top: 28px;
+      color: #18407a;
+    }
+    .exam-meta {
+      display: grid;
+      gap: 6px;
+      justify-content: center;
+      margin: 0 auto 20px;
+    }
+    .instructions {
+      background: #fff;
+      border: 1px solid rgba(0,0,0,0.08);
+      border-left: 4px solid #0d6efd;
+      padding: 16px 20px;
+      border-radius: 6px;
+    }
+    .instructions ul {
+      margin: 12px 0 0 18px;
+    }
+    .marks {
+      font-weight: 600;
+      color: #1d5bbf;
+    }
+    ol {
+      padding-left: 24px;
+    }
+    .question {
+      margin-bottom: 16px;
+    }
+    .question p {
+      margin: 0 0 8px;
+    }
+    .mc-options {
+      list-style: upper-alpha;
+      margin-top: 6px;
+    }
+    .response-lines {
+      border: 1px solid rgba(0,0,0,0.15);
+      border-radius: 4px;
+      min-height: 90px;
+      margin-top: 10px;
+      padding: 12px;
+      background: rgba(255,255,255,0.9);
+    }
+    .long-response .response-lines {
+      min-height: 180px;
+    }
+    footer {
+      text-align: center;
+      margin-top: 60px;
+      font-size: 0.9rem;
+      color: #666;
+    }
+    @media print {
+      body {
+        background: #fff;
+        color: #000;
+        padding: 20px 40px;
+      }
+      header {
+        border-bottom-color: #000;
+      }
+      h2 {
+        border-bottom-color: #000;
+      }
+      .instructions {
+        border-color: #000;
+        border-left-color: #000;
+      }
+      .response-lines {
+        min-height: 110px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Year 10 Industrial Technology Timber</h1>
+    <p class="exam-meta">
+      <span><strong>Summative Theory Examination</strong></span>
+      <span>Weeks 1&ndash;20 Knowledge &mdash; Duration: <strong>60 minutes</strong></span>
+    </p>
+  </header>
+
+  <section aria-labelledby="instructions-heading" class="instructions">
+    <h2 id="instructions-heading">Student Instructions</h2>
+    <ul>
+      <li>Read every question carefully before answering. Show all working where appropriate.</li>
+      <li>Write all responses in the spaces provided. If you require additional space, clearly label and attach extra sheets.</li>
+      <li>Approved equipment: pens, pencils, ruler, eraser and colouring pencils. Calculators are not required.</li>
+      <li>Answer all questions. Check that your name is on every sheet you submit.</li>
+      <li>Use the suggested timings as a guide so that you attempt every section within the 60 minute limit.</li>
+    </ul>
+    <p><span class="marks">Total marks: 60</span></p>
+    <p>Suggested timing: Part A &mdash; 15 minutes, Part B &mdash; 20 minutes, Part C &mdash; 25 minutes.</p>
+  </section>
+
+  <section aria-labelledby="part-a-heading">
+    <h2 id="part-a-heading">Part A &mdash; Multiple Choice (10 marks)</h2>
+    <p>Attempt all questions. Circle the letter that best answers each question. Each question is worth <strong>1 mark</strong>.</p>
+    <ol>
+      <li class="question">
+        <p>Which item of personal protective equipment (PPE) is essential when operating the mortiser during Week 4 practical work?</p>
+        <ol class="mc-options">
+          <li>Respirator and apron</li>
+          <li>Safety glasses and secure hair</li>
+          <li>Steel-cap boots only</li>
+          <li>Hi-vis vest</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>During Week 2 design development, which principle ensures the bedside table is both visually appealing and structurally stable?</p>
+        <ol class="mc-options">
+          <li>Symmetry and repetition</li>
+          <li>Balance and proportion</li>
+          <li>Colour theory</li>
+          <li>Contrast and texture</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>In the FEWTEL method from Week 3, which stage confirms the timber has the correct final width?</p>
+        <ol class="mc-options">
+          <li>Face</li>
+          <li>Edge</li>
+          <li>Width</li>
+          <li>Length</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>What is the primary purpose of conducting a dry clamp practice in Week 8 before gluing?</p>
+        <ol class="mc-options">
+          <li>To apply finish evenly</li>
+          <li>To check alignment and squareness of the assembly</li>
+          <li>To save time during final sanding</li>
+          <li>To stain the timber components</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>Which document developed in Week 8 details task sequence, tools, materials and safety controls?</p>
+        <ol class="mc-options">
+          <li>Gantt chart</li>
+          <li>Material Safety Data Sheet</li>
+          <li>Work Method Statement</li>
+          <li>Portfolio index</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>When refining mortise and tenon joints in Week 7, what indicates a correctly cut tenon?</p>
+        <ol class="mc-options">
+          <li>It slides freely with visible gaps</li>
+          <li>It requires hammering to seat</li>
+          <li>It fits snugly with light hand pressure</li>
+          <li>It is intentionally oversized for trimming later</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>Which Week 9&ndash;10 documentation best communicates advanced design features to stakeholders?</p>
+        <ol class="mc-options">
+          <li>Annotated orthogonal CAD drawings</li>
+          <li>Freehand pictorial sketch only</li>
+          <li>Material cutting list</li>
+          <li>Workshop maintenance checklist</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>According to Week 11 theory, when applying woodworking adhesive, you should primarily aim to:</p>
+        <ol class="mc-options">
+          <li>Use as much glue as possible to fill gaps</li>
+          <li>Apply evenly and clamp with consistent pressure</li>
+          <li>Allow glue to skin before clamping</li>
+          <li>Clamp without glue to maintain component position</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>Which finishing approach from Week 13 is best suited to highlighting natural grain with minimal surface film?</p>
+        <ol class="mc-options">
+          <li>Polyurethane varnish</li>
+          <li>Paint</li>
+          <li>Wax or oil finish</li>
+          <li>Lacquer with pigment</li>
+        </ol>
+      </li>
+      <li class="question">
+        <p>Week 16 sustainability discussions emphasised selecting timber that is:</p>
+        <ol class="mc-options">
+          <li>Locally grown regardless of harvesting practices</li>
+          <li>Certified by bodies such as the FSC</li>
+          <li>Cheapest per linear metre</li>
+          <li>Pre-finished to reduce labour time</li>
+        </ol>
+      </li>
+    </ol>
+  </section>
+
+  <section aria-labelledby="part-b-heading">
+    <h2 id="part-b-heading">Part B &mdash; Short Answer (24 marks)</h2>
+    <p>Attempt all questions. Write concise responses in the spaces provided.</p>
+    <ol start="11">
+      <li class="question">
+        <p><strong>(4 marks)</strong> Explain the four steps of the risk management process introduced in Week 1 and describe how they apply when preparing to use the bandsaw.</p>
+        <div class="response-lines" aria-label="Response area"></div>
+      </li>
+      <li class="question">
+        <p><strong>(4 marks)</strong> Week 5 focused on bandsaw safety. List two pre-use checks and two operational practices that protect users from injury.</p>
+        <div class="response-lines" aria-label="Response area"></div>
+      </li>
+      <li class="question">
+        <p><strong>(4 marks)</strong> During Week 11 costing activities, what information must be included in a project costing spreadsheet and why is accurate costing important for the bedside table project?</p>
+        <div class="response-lines" aria-label="Response area"></div>
+      </li>
+      <li class="question">
+        <p><strong>(4 marks)</strong> Outline the procedure for reading a Material Safety Data Sheet (MSDS) as explored in Week 15, and explain how it informs safe chemical handling.</p>
+        <div class="response-lines" aria-label="Response area"></div>
+      </li>
+      <li class="question">
+        <p><strong>(4 marks)</strong> Week 18 revision highlighted major theory areas. Summarise how effective time planning tools, such as a Gantt chart, support the completion of the bedside table project.</p>
+        <div class="response-lines" aria-label="Response area"></div>
+      </li>
+      <li class="question">
+        <p><strong>(4 marks)</strong> In Week 19, students reviewed workshop maintenance. Describe the steps involved in safely shutting down the workshop at the end of a session and state why each step is important.</p>
+        <div class="response-lines" aria-label="Response area"></div>
+      </li>
+    </ol>
+  </section>
+
+  <section aria-labelledby="part-c-heading" class="long-response">
+    <h2 id="part-c-heading">Part C &mdash; Extended Response (26 marks)</h2>
+    <p>Answer <strong>both</strong> questions. Use extended paragraphs, annotated diagrams and tables where appropriate.</p>
+    <ol start="17">
+      <li class="question">
+        <p><strong>(12 marks)</strong> Drawing on learning from Weeks 2, 3, 8 and 12, explain how accurate measuring, the FEWTEL process, dry clamping and project sequencing combine to produce a precise and efficient bedside table build. In your response, discuss potential consequences when any of these steps are overlooked and provide strategies to avoid errors.</p>
+        <div class="response-lines" aria-label="Response area"></div>
+      </li>
+      <li class="question">
+        <p><strong>(14 marks)</strong> Weeks 13&ndash;17 explored finishing, sustainability, portfolio presentation and evaluation. Compose a detailed evaluation report for a finished bedside table that addresses: choice of finish, application technique, sustainability of materials, WHS considerations, portfolio evidence, and criteria for judging overall success. Suggest at least two improvements for future projects, justifying each recommendation.</p>
+        <div class="response-lines" aria-label="Response area"></div>
+      </li>
+    </ol>
+  </section>
+
+  <footer>
+    <p>End of paper &mdash; ensure all responses are complete before submitting.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone 60-minute theory examination page covering Weeks 1–20 with multiple choice, short answer, and extended response sections
- link the new exam from the Assessments section so students can access it alongside other resources

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68feac5e747483268eb359df8307438c