### PR TITLE
Add layout partials for Bedside Table

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,18 +291,7 @@ summary { font-weight: bold; }
 
 </head>
 <body>
-<header>
-  <h1><b>Stage 5 Industrial Technology Timber - Bedside Table Project</b> - 2025</h1>
-  <p>Resources, Projects, and Content for Learning</p>
-  <div class="header-image">
-    <!-- STAFF: Replace 'sample_project.png' with your project image -->
-      <img src="table.png" alt="Bedside Table" style="max-width:300px; width:100%; margin-top:20px; border-radius:5px;" />
-    <div class="plan-link" style="margin-top:10px;">
-      <!-- STAFF: Update link to your project's plan PDF -->
-      <a href="Drafted.pdf" style="background:#17a2b8; color:#fff; padding:10px 15px; border-radius:4px; font-weight:bold; display:inline-block; margin-left:5px;" target="_blank">Breadboard Plan (PDF)</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <section class="google-classroom" aria-label="Google Classroom Invitation">
   <h2>Join Our Google Classroom</h2>
@@ -311,17 +300,6 @@ summary { font-weight: bold; }
   <!-- STAFF: Update the Google Classroom link -->
   <a href="https://classroom.google.com/w/NzQ5MDQxMzk4MjAz/t/all" target="_blank">Join Google Classroom</a>
 </section>
-
-<nav aria-label="Main Navigation">
-  <a class="nav-link active" data-section="program" href="#program">Subject Program</a>
-  <a class="nav-link" data-section="syllabus" href="#syllabus">Syllabus</a>
-  <a class="nav-link" data-section="assessment" href="#assessment">Assessments</a>
-  <a class="nav-link" data-section="project-unit" href="#project-unit">Bedside Table Project Unit</a>
-  <a class="nav-link" data-section="main-theory" href="#main-theory">Main Theory Content</a>
-  <a class="nav-link" data-section="support-activities" href="#support-activities">Support Theory Content (Optional)</a>
-  <a class="nav-link" data-section="advanced-activities" href="#advanced-activities">Advanced Theory Content (Optional)</a>
-  <a class="nav-link" href="timber-technology-assessment.html" target="_blank" rel="noopener">End of Year Examination</a>
-</nav>
 
 <main class="content">
 
@@ -390,6 +368,9 @@ summary { font-weight: bold; }
   </div>
 </div>
 
+<div id="footer-placeholder"></div>
+
+<script src="scripts/loadPartials.js"></script>
 <script src="loadSections.js"></script>
 <script src="scripts/nav.js"></script>
 <script src="scripts/quiz.js"></script>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>&copy; 2025 Bedside Table Project. All rights reserved.</p>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,23 @@
+<header>
+  <h1><b>Stage 5 Industrial Technology Timber - Bedside Table Project</b> - 2025</h1>
+  <p>Resources, Projects, and Content for Learning</p>
+  <div class="header-image">
+    <!-- STAFF: Replace 'sample_project.png' with your project image -->
+      <img src="table.png" alt="Bedside Table" style="max-width:300px; width:100%; margin-top:20px; border-radius:5px;" />
+    <div class="plan-link" style="margin-top:10px;">
+      <!-- STAFF: Update link to your project's plan PDF -->
+      <a href="Drafted.pdf" style="background:#17a2b8; color:#fff; padding:10px 15px; border-radius:4px; font-weight:bold; display:inline-block; margin-left:5px;" target="_blank">Breadboard Plan (PDF)</a>
+    </div>
+  </div>
+</header>
+
+<nav aria-label="Main Navigation">
+  <a class="nav-link active" data-section="program" href="#program">Subject Program</a>
+  <a class="nav-link" data-section="syllabus" href="#syllabus">Syllabus</a>
+  <a class="nav-link" data-section="assessment" href="#assessment">Assessments</a>
+  <a class="nav-link" data-section="project-unit" href="#project-unit">Bedside Table Project Unit</a>
+  <a class="nav-link" data-section="main-theory" href="#main-theory">Main Theory Content</a>
+  <a class="nav-link" data-section="support-activities" href="#support-activities">Support Theory Content (Optional)</a>
+  <a class="nav-link" data-section="advanced-activities" href="#advanced-activities">Advanced Theory Content (Optional)</a>
+  <a class="nav-link" href="timber-technology-assessment.html" target="_blank" rel="noopener">End of Year Examination</a>
+</nav>

--- a/partials/week-card.html
+++ b/partials/week-card.html
@@ -1,0 +1,39 @@
+<article class="week-card">
+  <header class="week-card__header">
+    <h3 class="week-card__title">Week Title</h3>
+    <p class="week-card__dates">Week dates</p>
+  </header>
+
+  <section class="week-card__section week-card__overview">
+    <h4>Overview</h4>
+    <p>Summary of the week's activities and goals.</p>
+  </section>
+
+  <section class="week-card__section week-card__learning-focus">
+    <h4>Learning Focus</h4>
+    <ul>
+      <li>Key concept or skill</li>
+    </ul>
+  </section>
+
+  <section class="week-card__section week-card__resources">
+    <h4>Resources</h4>
+    <ul>
+      <li>Links, documents, or media</li>
+    </ul>
+  </section>
+
+  <section class="week-card__section week-card__tasks">
+    <h4>Tasks</h4>
+    <ul>
+      <li>Activity or assignment</li>
+    </ul>
+  </section>
+
+  <section class="week-card__section week-card__assessment">
+    <h4>Assessment Evidence</h4>
+    <ul>
+      <li>Evidence of learning</li>
+    </ul>
+  </section>
+</article>

--- a/scripts/loadPartials.js
+++ b/scripts/loadPartials.js
@@ -1,0 +1,53 @@
+async function insertPartial(placeholderId, partialPath) {
+  const placeholder = document.getElementById(placeholderId);
+  if (!placeholder) return;
+
+  try {
+    const response = await fetch(partialPath);
+    placeholder.innerHTML = await response.text();
+  } catch (error) {
+    console.error(`Failed to load partial: ${partialPath}`, error);
+  }
+}
+
+async function loadPartials() {
+  await Promise.all([
+    insertPartial('header-placeholder', 'partials/header.html'),
+    insertPartial('footer-placeholder', 'partials/footer.html')
+  ]);
+
+  if (typeof initPage === 'function') {
+    initPage.hasRun = false;
+    initPage();
+  }
+}
+
+let weekCardTemplate;
+
+async function getWeekCardTemplate() {
+  if (weekCardTemplate) return weekCardTemplate;
+
+  try {
+    const response = await fetch('partials/week-card.html');
+    const html = await response.text();
+    const template = document.createElement('template');
+    template.innerHTML = html.trim();
+    weekCardTemplate = template;
+  } catch (error) {
+    console.error('Failed to load week card template', error);
+    weekCardTemplate = document.createElement('template');
+  }
+
+  return weekCardTemplate;
+}
+
+async function createWeekCard() {
+  const template = await getWeekCardTemplate();
+  const content = template.content.firstElementChild;
+  if (!content) return document.createElement('div');
+  return content.cloneNode(true);
+}
+
+document.addEventListener('DOMContentLoaded', loadPartials);
+
+window.createWeekCard = createWeekCard;


### PR DESCRIPTION
## Summary
- add header, footer, and week-card partials to centralize shared layout elements
- create a loadPartials script to fetch layout partials and expose a reusable week card factory
- update index page to use partial placeholders and include the loader script

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489e7e3db08326a3b1ffd96060ae9d)